### PR TITLE
Adding functionality for createIndex on a collection

### DIFF
--- a/src/MongoCollection.lua
+++ b/src/MongoCollection.lua
@@ -265,6 +265,16 @@ local MongoCollection = {__mode="k"}
 		return MongoCursor(self, cursor_t)
 	end
 
+	---
+	-- Create and index on any field or combination of fields in the collection.
+	-- Example usage at @{indexing.lua}.
+	-- @tparam {table,...} key value pairs of keys to be indexed
+	-- @tparam {table,...} key value pairs of options to be used when creating index
+	-- @return a boolean true if index created successfully
+	function MongoCollection:createIndex(keys,ops)
+	    return self.collection_t:collection_create_index(luaBSONObjects,keys,ops)
+	end
+
 local metatable = {
 	__index = MongoCollection,
 	__call = function(table, ...) 


### PR DESCRIPTION
Adding functionality to create an index for a collection using `collection:createIndex(keys, options) `command. This is a test example that allows you to see it in action. The only issue that I was not able to track down was the use of the options values. I seem to be doing everything correctly, according to the example on the following page: https://api.mongodb.com/c/current/mongoc_index_opt_t.html